### PR TITLE
Headless support: SimRuntime autoload + parts migration

### DIFF
--- a/addons/oip_comms/comms_registration.gd
+++ b/addons/oip_comms/comms_registration.gd
@@ -1,0 +1,29 @@
+## Shared OIPComms tag-group registration. Extracted from the editor dock
+## (oip_comms_dock.gd) so headless runners can register the same way.
+##
+## tag_groups_data items use the dock's on-disk shape:
+##   { name, polling_rate, protocol, gateway, path, cpu }
+## where `protocol` is the numeric string "0".."3" mapping to
+## ab_eip / modbus_tcp / opc_ua / s7. `polling_rate` is a string in ms.
+class_name OIPCommsRegistration
+
+
+const PROTOCOLS := {
+	"0": "ab_eip",
+	"1": "modbus_tcp",
+	"2": "opc_ua",
+	"3": "s7",
+}
+
+
+static func register_tag_groups(tag_groups_data: Array) -> void:
+	OIPComms.clear_tag_groups()
+	for tag_group_data: Dictionary in tag_groups_data:
+		var n: String = tag_group_data.name
+		var pr: String = tag_group_data.polling_rate
+		var pt: String = PROTOCOLS.get(String(tag_group_data.protocol), "")
+		var g: String = tag_group_data.gateway
+		var p: String = tag_group_data.path
+		var c: String = tag_group_data.cpu
+		OIPComms.register_tag_group(n, int(pr), pt, g, p, c)
+	OIPComms.tag_groups_registered.emit()

--- a/addons/oip_comms/comms_registration.gd.uid
+++ b/addons/oip_comms/comms_registration.gd.uid
@@ -1,0 +1,1 @@
+uid://3p4fnmpgak1x

--- a/addons/oip_comms/controls/oip_comms_dock.gd
+++ b/addons/oip_comms/controls/oip_comms_dock.gd
@@ -180,23 +180,7 @@ func _on_AddTagGroup_pressed() -> void:
 	mark_changes_present()
 
 func register_tag_groups() -> void:
-	OIPComms.clear_tag_groups()
-	for tag_group_data: Dictionary in tag_groups_data:
-		var n: String = tag_group_data.name
-		var pr: String = tag_group_data.polling_rate
-
-		var pt_num: String = tag_group_data.protocol
-		var pt := ""
-		if pt_num == "0": pt = "ab_eip"
-		elif pt_num == "1": pt = "modbus_tcp"
-		elif pt_num == "2": pt = "opc_ua"
-		elif pt_num == "3": pt = "s7"
-
-		var g: String = tag_group_data.gateway
-		var p: String = tag_group_data.path
-		var c: String = tag_group_data.cpu
-		OIPComms.register_tag_group(n, int(pr), pt, g, p, c)
-	OIPComms.tag_groups_registered.emit()
+	OIPCommsRegistration.register_tag_groups(tag_groups_data)
 
 func _on_EnableComms_toggled(toggled_on: bool) -> void:
 	OIPComms.set_enable_comms(toggled_on)

--- a/addons/sim_runtime/plugin.cfg
+++ b/addons/sim_runtime/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="SimRuntime Editor Bridge"
+description="Forwards EditorInterface simulation signals to the SimRuntime autoload so parts work in both editor and headless contexts."
+author="Open Industry Project contributors"
+version="0.1"
+script="sim_runtime_editor_bridge.gd"

--- a/addons/sim_runtime/sim_runtime.gd
+++ b/addons/sim_runtime/sim_runtime.gd
@@ -1,0 +1,67 @@
+## Headless-friendly mirror of EditorInterface's simulation lifecycle.
+##
+## Parts (BeltConveyor, DiffuseSensor, ...) connect to SimRuntime instead of
+## EditorInterface, so they work in both editor and headless runs. In the
+## editor, sim_runtime_editor_bridge.gd forwards EditorInterface signals
+## here. In headless, a runner script calls start_simulation() / stop_simulation()
+## directly.
+##
+## Registered as autoload `SimRuntime` in project.godot — accessed globally
+## by that name. No `class_name` here (would conflict with the autoload).
+extends Node
+
+signal simulation_started
+signal simulation_stopped
+signal simulation_pause_toggled(paused: bool)
+signal transform_requested(data: Dictionary)
+signal transform_commited
+
+var _running: bool = false
+var _paused: bool = false
+
+
+func _ready() -> void:
+	simulation_started.connect(_on_started)
+	simulation_stopped.connect(_on_stopped)
+	simulation_pause_toggled.connect(_on_pause_toggled)
+
+
+func is_simulation_running() -> bool:
+	return _running
+
+
+func is_simulation_paused() -> bool:
+	return _paused
+
+
+func start_simulation() -> void:
+	if _running:
+		return
+	simulation_started.emit()
+
+
+func stop_simulation() -> void:
+	if not _running:
+		return
+	simulation_stopped.emit()
+
+
+func toggle_pause_simulation() -> void:
+	simulation_pause_toggled.emit(not _paused)
+
+
+func _on_started() -> void:
+	_running = true
+	_paused = false
+	if Engine.has_singleton(&"OIPComms"):
+		Engine.get_singleton(&"OIPComms").set_sim_running(true)
+
+
+func _on_stopped() -> void:
+	_running = false
+	if Engine.has_singleton(&"OIPComms"):
+		Engine.get_singleton(&"OIPComms").set_sim_running(false)
+
+
+func _on_pause_toggled(paused: bool) -> void:
+	_paused = paused

--- a/addons/sim_runtime/sim_runtime.gd.uid
+++ b/addons/sim_runtime/sim_runtime.gd.uid
@@ -1,0 +1,1 @@
+uid://d4gbokqgmvreu

--- a/addons/sim_runtime/sim_runtime_editor_bridge.gd
+++ b/addons/sim_runtime/sim_runtime_editor_bridge.gd
@@ -1,0 +1,24 @@
+## Editor-only: forwards EditorInterface simulation signals to the
+## SimRuntime autoload so parts (which now connect to SimRuntime) keep
+## working when the user presses Play in the editor.
+##
+## In headless this plugin is not loaded; HeadlessRunner-style scripts
+## drive SimRuntime directly via start_simulation() / stop_simulation().
+@tool
+extends EditorPlugin
+
+
+func _enter_tree() -> void:
+	EditorInterface.simulation_started.connect(SimRuntime.simulation_started.emit)
+	EditorInterface.simulation_stopped.connect(SimRuntime.simulation_stopped.emit)
+	EditorInterface.simulation_pause_toggled.connect(SimRuntime.simulation_pause_toggled.emit)
+	EditorInterface.transform_requested.connect(SimRuntime.transform_requested.emit)
+	EditorInterface.transform_commited.connect(SimRuntime.transform_commited.emit)
+
+
+func _exit_tree() -> void:
+	EditorInterface.simulation_started.disconnect(SimRuntime.simulation_started.emit)
+	EditorInterface.simulation_stopped.disconnect(SimRuntime.simulation_stopped.emit)
+	EditorInterface.simulation_pause_toggled.disconnect(SimRuntime.simulation_pause_toggled.emit)
+	EditorInterface.transform_requested.disconnect(SimRuntime.transform_requested.emit)
+	EditorInterface.transform_commited.disconnect(SimRuntime.transform_commited.emit)

--- a/addons/sim_runtime/sim_runtime_editor_bridge.gd.uid
+++ b/addons/sim_runtime/sim_runtime_editor_bridge.gd.uid
@@ -1,0 +1,1 @@
+uid://dceyfow4ak0ua

--- a/parts/generic_data.gd
+++ b/parts/generic_data.gd
@@ -53,12 +53,12 @@ func _enter_tree() -> void:
 		setup = true
 
 	tag_group_name = OIPCommsSetup.default_tag_group(tag_group_name)
-	EditorInterface.simulation_started.connect(_on_simulation_started)
+	SimRuntime.simulation_started.connect(_on_simulation_started)
 	OIPCommsSetup.connect_comms(self, _tag_group_initialized, _tag_group_polled)
 
 
 func _exit_tree() -> void:
-	EditorInterface.simulation_started.disconnect(_on_simulation_started)
+	SimRuntime.simulation_started.disconnect(_on_simulation_started)
 	OIPCommsSetup.disconnect_comms(self, _tag_group_initialized, _tag_group_polled)
 
 

--- a/project.godot
+++ b/project.godot
@@ -22,6 +22,7 @@ run/scene_time_scale=1.0
 
 [autoload]
 
+SimRuntime="*res://addons/sim_runtime/sim_runtime.gd"
 ConveyorSnapping="*res://addons/oip_ui/Autoload/ConveyorSnapping.gd"
 StructureSnapping="*res://addons/oip_ui/Autoload/StructureSnapping.gd"
 
@@ -55,7 +56,7 @@ naming/scene_name_casing=1
 
 [editor_plugins]
 
-enabled=PackedStringArray("res://addons/conveyor_gizmo/plugin.cfg", "res://addons/editor-pilot-mode/plugin.cfg", "res://addons/gantry_gizmo/plugin.cfg", "res://addons/oip_comms/plugin.cfg", "res://addons/oip_ui/plugin.cfg", "res://addons/opc_ua_browser/plugin.cfg", "res://addons/robot_gizmo/plugin.cfg", "res://addons/scene-library/plugin.cfg", "res://addons/tag_groups/plugin.cfg")
+enabled=PackedStringArray("res://addons/conveyor_gizmo/plugin.cfg", "res://addons/editor-pilot-mode/plugin.cfg", "res://addons/gantry_gizmo/plugin.cfg", "res://addons/oip_comms/plugin.cfg", "res://addons/oip_ui/plugin.cfg", "res://addons/opc_ua_browser/plugin.cfg", "res://addons/robot_gizmo/plugin.cfg", "res://addons/scene-library/plugin.cfg", "res://addons/sim_runtime/plugin.cfg", "res://addons/tag_groups/plugin.cfg")
 
 [filesystem]
 

--- a/src/BladeStop/blade_stop.gd
+++ b/src/BladeStop/blade_stop.gd
@@ -93,14 +93,14 @@ func _enter_tree() -> void:
 	if has_meta("is_preview"):
 		return
 	tag_group_name = OIPCommsSetup.default_tag_group(tag_group_name)
-	EditorInterface.simulation_started.connect(_on_simulation_started)
+	SimRuntime.simulation_started.connect(_on_simulation_started)
 	OIPCommsSetup.connect_comms(self, _tag_group_initialized, _tag_group_polled)
 
 
 func _exit_tree() -> void:
 	if has_meta("is_preview"):
 		return
-	EditorInterface.simulation_started.disconnect(_on_simulation_started)
+	SimRuntime.simulation_started.disconnect(_on_simulation_started)
 	OIPCommsSetup.disconnect_comms(self, _tag_group_initialized, _tag_group_polled)
 
 

--- a/src/Box/Box.gd
+++ b/src/Box/Box.gd
@@ -37,25 +37,25 @@ func _init() -> void:
 
 func _enter_tree() -> void:
 	super._enter_tree()
-	EditorInterface.simulation_started.connect(_on_simulation_started)
-	EditorInterface.simulation_stopped.connect(_on_simulation_ended)
-	EditorInterface.simulation_pause_toggled.connect(_on_simulation_set_paused)
+	SimRuntime.simulation_started.connect(_on_simulation_started)
+	SimRuntime.simulation_stopped.connect(_on_simulation_ended)
+	SimRuntime.simulation_pause_toggled.connect(_on_simulation_set_paused)
 
 
 func _ready() -> void:
 	_on_size_changed()
 	if color != Color.WHITE:
 		set("color", color)
-	_rigid_body_3d.freeze = not EditorInterface.is_simulation_running()
-	if EditorInterface.is_simulation_running():
+	_rigid_body_3d.freeze = not SimRuntime.is_simulation_running()
+	if SimRuntime.is_simulation_running():
 		instanced = true
 		_rigid_body_3d.linear_velocity = initial_linear_velocity
 
 
 func _exit_tree() -> void:
-	EditorInterface.simulation_started.disconnect(_on_simulation_started)
-	EditorInterface.simulation_stopped.disconnect(_on_simulation_ended)
-	EditorInterface.simulation_pause_toggled.disconnect(_on_simulation_set_paused)
+	SimRuntime.simulation_started.disconnect(_on_simulation_started)
+	SimRuntime.simulation_stopped.disconnect(_on_simulation_ended)
+	SimRuntime.simulation_pause_toggled.disconnect(_on_simulation_set_paused)
 	super._exit_tree()
 	if instanced:
 		queue_free()
@@ -66,7 +66,7 @@ func _get_constrained_size(new_size: Vector3) -> Vector3:
 
 
 func selected() -> void:
-	if _paused or not EditorInterface.is_simulation_running():
+	if _paused or not SimRuntime.is_simulation_running():
 		return
 
 	if _rigid_body_3d.freeze:

--- a/src/BoxSpawner/box_spawner.gd
+++ b/src/BoxSpawner/box_spawner.gd
@@ -62,8 +62,8 @@ func _enter_tree() -> void:
 	_reset_spawn_cycle()
 
 func _ready() -> void:
-	EditorInterface.simulation_started.connect(_on_simulation_started)
-	EditorInterface.simulation_stopped.connect(_on_simulation_ended)
+	SimRuntime.simulation_started.connect(_on_simulation_started)
+	SimRuntime.simulation_stopped.connect(_on_simulation_ended)
 	_on_size_changed()
 	_change_texture()
 
@@ -78,10 +78,10 @@ func _on_size_changed() -> void:
 			box_shape.size = size
 
 func _physics_process(delta: float) -> void:
-	if conveyor and EditorInterface.is_simulation_running() and &"speed" in conveyor:
+	if conveyor and SimRuntime.is_simulation_running() and &"speed" in conveyor:
 		_conveyor_stopped = conveyor.speed == 0
 
-	if disable or _conveyor_stopped or not EditorInterface.is_simulation_running():
+	if disable or _conveyor_stopped or not SimRuntime.is_simulation_running():
 		return
 	
 	_scan_interval += delta

--- a/src/ChainTransfer/base.gd
+++ b/src/ChainTransfer/base.gd
@@ -69,7 +69,7 @@ func _physics_process(delta: float) -> void:
 		if _chain_material and owner:
 			var chain_meters: float = owner.scale.x * _chain_base_length
 			var chain_links_per_meter: float = round(owner.scale.x * _chain_scale) / chain_meters
-			if not EditorInterface.is_simulation_paused():
+			if not SimRuntime.is_simulation_paused():
 				_chain_position += owner.speed / chain_meters * delta
 			_chain_position = fmod((fmod(_chain_position, 1) + 1.0), 1)
 			_chain_end_position += owner.speed * chain_links_per_meter / _chain_end_scale * delta

--- a/src/ChainTransfer/chain_transfer.gd
+++ b/src/ChainTransfer/chain_transfer.gd
@@ -100,8 +100,8 @@ func _ready() -> void:
 func _enter_tree() -> void:
 	if has_meta("is_preview"):
 		return
-	EditorInterface.simulation_started.connect(_on_simulation_started)
-	EditorInterface.simulation_stopped.connect(_on_simulation_ended)
+	SimRuntime.simulation_started.connect(_on_simulation_started)
+	SimRuntime.simulation_stopped.connect(_on_simulation_ended)
 	speed_tag_group_name = OIPCommsSetup.default_tag_group(speed_tag_group_name)
 	popup_tag_group_name = OIPCommsSetup.default_tag_group(popup_tag_group_name)
 	OIPCommsSetup.connect_comms(self, _tag_group_initialized, _tag_group_polled)
@@ -109,8 +109,8 @@ func _enter_tree() -> void:
 func _exit_tree() -> void:
 	if has_meta("is_preview"):
 		return
-	EditorInterface.simulation_started.disconnect(_on_simulation_started)
-	EditorInterface.simulation_stopped.disconnect(_on_simulation_ended)
+	SimRuntime.simulation_started.disconnect(_on_simulation_started)
+	SimRuntime.simulation_stopped.disconnect(_on_simulation_ended)
 	OIPCommsSetup.disconnect_comms(self, _tag_group_initialized, _tag_group_polled)
 
 func _validate_property(property: Dictionary) -> void:
@@ -145,7 +145,7 @@ func _sync_chain_count() -> void:
 		var chain_base := _chain_transfer_base_scene.instantiate() as ChainTransferBase
 		bases.add_child(chain_base, true)
 		chain_base.active = popup_chains
-		if EditorInterface.is_simulation_running():
+		if SimRuntime.is_simulation_running():
 			chain_base.turn_on()
 	_position_bases()
 	_update_simple_shape()

--- a/src/ColorSensor/color_sensor.gd
+++ b/src/ColorSensor/color_sensor.gd
@@ -85,14 +85,14 @@ func _enter_tree() -> void:
 	_ray_query.collision_mask = 8
 
 	tag_group_name = OIPCommsSetup.default_tag_group(tag_group_name)
-	EditorInterface.simulation_started.connect(_on_simulation_started)
+	SimRuntime.simulation_started.connect(_on_simulation_started)
 	OIPCommsSetup.connect_comms(self, _tag_group_initialized)
 
 
 func _exit_tree() -> void:
 	RenderingServer.free_rid(_instance)
 	SensorBeamCache.clear_beam(get_instance_id())
-	EditorInterface.simulation_started.disconnect(_on_simulation_started)
+	SimRuntime.simulation_started.disconnect(_on_simulation_started)
 	OIPCommsSetup.disconnect_comms(self, _tag_group_initialized)
 
 

--- a/src/Conveyor/belt_conveyor.gd
+++ b/src/Conveyor/belt_conveyor.gd
@@ -148,8 +148,8 @@ func _enter_tree() -> void:
 
 	speed_tag_group_name = OIPCommsSetup.default_tag_group(speed_tag_group_name)
 	running_tag_group_name = OIPCommsSetup.default_tag_group(running_tag_group_name)
-	EditorInterface.simulation_started.connect(_on_simulation_started)
-	EditorInterface.simulation_stopped.connect(_on_simulation_ended)
+	SimRuntime.simulation_started.connect(_on_simulation_started)
+	SimRuntime.simulation_stopped.connect(_on_simulation_ended)
 	OIPCommsSetup.connect_comms(self, _tag_group_initialized, _tag_group_polled)
 
 
@@ -191,11 +191,11 @@ func _refresh_frame_management() -> void:
 
 
 func _physics_process(delta: float) -> void:
-	if EditorInterface.is_simulation_running():
+	if SimRuntime.is_simulation_running():
 		var local_left := _sb.global_transform.basis.x.normalized()
 		var velocity := local_left * speed
 		_sb.constant_linear_velocity = velocity
-		if not EditorInterface.is_simulation_paused():
+		if not SimRuntime.is_simulation_paused():
 			_belt_position = fmod(_belt_position + speed * delta, 1.0)
 		if speed != 0:
 			(_belt_material as ShaderMaterial).set_shader_parameter("BeltPosition", _belt_position)
@@ -204,8 +204,8 @@ func _physics_process(delta: float) -> void:
 func _exit_tree() -> void:
 	if _flow_arrow:
 		FlowDirectionArrow.unregister(_flow_arrow)
-	EditorInterface.simulation_started.disconnect(_on_simulation_started)
-	EditorInterface.simulation_stopped.disconnect(_on_simulation_ended)
+	SimRuntime.simulation_started.disconnect(_on_simulation_started)
+	SimRuntime.simulation_stopped.disconnect(_on_simulation_ended)
 	OIPCommsSetup.disconnect_comms(self, _tag_group_initialized, _tag_group_polled)
 	super._exit_tree()
 

--- a/src/Conveyor/curved_belt_conveyor.gd
+++ b/src/Conveyor/curved_belt_conveyor.gd
@@ -314,7 +314,7 @@ func _update_belt_ends() -> void:
 	for body: StaticBody3D in [_end_body1, _end_body2]:
 		if not body:
 			continue
-		if EditorInterface.is_simulation_running() and _linear_speed != 0:
+		if SimRuntime.is_simulation_running() and _linear_speed != 0:
 			var local_front: Vector3 = body.global_transform.basis.z.normalized()
 			var vel: Vector3 = local_front * _linear_speed / roller_radius
 			body.constant_angular_velocity = vel
@@ -597,16 +597,16 @@ func _enter_tree() -> void:
 
 	speed_tag_group_name = OIPCommsSetup.default_tag_group(speed_tag_group_name)
 	running_tag_group_name = OIPCommsSetup.default_tag_group(running_tag_group_name)
-	EditorInterface.simulation_started.connect(_on_simulation_started)
-	EditorInterface.simulation_stopped.connect(_on_simulation_ended)
+	SimRuntime.simulation_started.connect(_on_simulation_started)
+	SimRuntime.simulation_stopped.connect(_on_simulation_ended)
 	OIPCommsSetup.connect_comms(self, _tag_group_initialized, _tag_group_polled)
 
 
 func _exit_tree() -> void:
 	if _flow_arrow:
 		FlowDirectionArrow.unregister(_flow_arrow)
-	EditorInterface.simulation_started.disconnect(_on_simulation_started)
-	EditorInterface.simulation_stopped.disconnect(_on_simulation_ended)
+	SimRuntime.simulation_started.disconnect(_on_simulation_started)
+	SimRuntime.simulation_stopped.disconnect(_on_simulation_ended)
 	OIPCommsSetup.disconnect_comms(self, _tag_group_initialized, _tag_group_polled)
 
 
@@ -631,11 +631,11 @@ func _recalculate_speeds() -> void:
 	_update_belt_ends()
 
 func _physics_process(delta: float) -> void:
-	if EditorInterface.is_simulation_running():
+	if SimRuntime.is_simulation_running():
 		var local_up := _sb.global_transform.basis.y.normalized()
 		var velocity := -local_up * _angular_speed
 		_sb.constant_angular_velocity = velocity
-		if not EditorInterface.is_simulation_paused():
+		if not SimRuntime.is_simulation_paused():
 			_belt_position = fmod(_belt_position + _linear_speed * delta, 1.0)
 		if _linear_speed != 0:
 			(_belt_material as ShaderMaterial).set_shader_parameter("BeltPosition", _belt_position)

--- a/src/DiffuseSensor/diffuse_sensor.gd
+++ b/src/DiffuseSensor/diffuse_sensor.gd
@@ -83,14 +83,14 @@ func _enter_tree() -> void:
 	_ray_query.collision_mask = 8
 
 	tag_group_name = OIPCommsSetup.default_tag_group(tag_group_name)
-	EditorInterface.simulation_started.connect(_on_simulation_started)
+	SimRuntime.simulation_started.connect(_on_simulation_started)
 	OIPCommsSetup.connect_comms(self, _tag_group_initialized)
 
 
 func _exit_tree() -> void:
 	RenderingServer.free_rid(_instance)
 	SensorBeamCache.clear_beam(get_instance_id())
-	EditorInterface.simulation_started.disconnect(_on_simulation_started)
+	SimRuntime.simulation_started.disconnect(_on_simulation_started)
 	OIPCommsSetup.disconnect_comms(self, _tag_group_initialized)
 
 

--- a/src/Diverter/diverter.gd
+++ b/src/Diverter/diverter.gd
@@ -42,13 +42,13 @@ func _enter_tree() -> void:
 	if has_meta("is_preview"):
 		return
 	tag_group_name = OIPCommsSetup.default_tag_group(tag_group_name)
-	EditorInterface.simulation_started.connect(_on_simulation_started)
+	SimRuntime.simulation_started.connect(_on_simulation_started)
 	OIPCommsSetup.connect_comms(self, _tag_group_initialized, _tag_group_polled)
 
 func _exit_tree() -> void:
 	if has_meta("is_preview"):
 		return
-	EditorInterface.simulation_started.disconnect(_on_simulation_started)
+	SimRuntime.simulation_started.disconnect(_on_simulation_started)
 	OIPCommsSetup.disconnect_comms(self, _tag_group_initialized, _tag_group_polled)
 
 func get_snap_features() -> Array:

--- a/src/Gantry/gantry.gd
+++ b/src/Gantry/gantry.gd
@@ -145,18 +145,18 @@ func _enter_tree() -> void:
 	tag_group_name = OIPCommsSetup.default_tag_group(tag_group_name)
 	_setup_node_references()
 
-	if not EditorInterface.simulation_started.is_connected(_on_simulation_started):
-		EditorInterface.simulation_started.connect(_on_simulation_started)
-	if not EditorInterface.simulation_stopped.is_connected(_on_simulation_ended):
-		EditorInterface.simulation_stopped.connect(_on_simulation_ended)
+	if not SimRuntime.simulation_started.is_connected(_on_simulation_started):
+		SimRuntime.simulation_started.connect(_on_simulation_started)
+	if not SimRuntime.simulation_stopped.is_connected(_on_simulation_ended):
+		SimRuntime.simulation_stopped.connect(_on_simulation_ended)
 	OIPCommsSetup.connect_comms(self, _tag_group_initialized, _tag_group_polled)
 
 
 func _exit_tree() -> void:
-	if EditorInterface.simulation_started.is_connected(_on_simulation_started):
-		EditorInterface.simulation_started.disconnect(_on_simulation_started)
-	if EditorInterface.simulation_stopped.is_connected(_on_simulation_ended):
-		EditorInterface.simulation_stopped.disconnect(_on_simulation_ended)
+	if SimRuntime.simulation_started.is_connected(_on_simulation_started):
+		SimRuntime.simulation_started.disconnect(_on_simulation_started)
+	if SimRuntime.simulation_stopped.is_connected(_on_simulation_ended):
+		SimRuntime.simulation_stopped.disconnect(_on_simulation_ended)
 	OIPCommsSetup.disconnect_comms(self, _tag_group_initialized, _tag_group_polled)
 
 
@@ -645,7 +645,8 @@ func move_to_position(target_positions: Array, instant: bool = false) -> void:
 			max_dist = max(max_dist, abs(target_positions[i] - current[i]))
 
 		var duration: float = max(max_dist / motion_speed, 0.1)
-		EditorInterface.mark_scene_as_unsaved()
+		if Engine.is_editor_hint():
+			EditorInterface.mark_scene_as_unsaved()
 		_motion_tween = create_tween()
 		_motion_tween.set_parallel(true)
 		_motion_tween.tween_property(self, "x_position", target_positions[0], duration)

--- a/src/LaserSensor/laser_sensor.gd
+++ b/src/LaserSensor/laser_sensor.gd
@@ -69,14 +69,14 @@ func _enter_tree() -> void:
 	_ray_query.collision_mask = 8
 
 	tag_group_name = OIPCommsSetup.default_tag_group(tag_group_name)
-	EditorInterface.simulation_started.connect(_on_simulation_started)
+	SimRuntime.simulation_started.connect(_on_simulation_started)
 	OIPCommsSetup.connect_comms(self, _tag_group_initialized)
 
 
 func _exit_tree() -> void:
 	RenderingServer.free_rid(_instance)
 	SensorBeamCache.clear_beam(get_instance_id())
-	EditorInterface.simulation_started.disconnect(_on_simulation_started)
+	SimRuntime.simulation_started.disconnect(_on_simulation_started)
 	OIPCommsSetup.disconnect_comms(self, _tag_group_initialized)
 
 

--- a/src/Pallet/pallet.gd
+++ b/src/Pallet/pallet.gd
@@ -30,27 +30,27 @@ var _enable_initial_transform: bool = false
 @onready var _mesh_instance_3d: MeshInstance3D = $RigidBody3D/MeshInstance3D
 
 func _enter_tree() -> void:
-	EditorInterface.simulation_started.connect(_on_simulation_started)
-	EditorInterface.simulation_stopped.connect(_on_simulation_ended)
-	EditorInterface.simulation_pause_toggled.connect(_on_simulation_set_paused)
+	SimRuntime.simulation_started.connect(_on_simulation_started)
+	SimRuntime.simulation_stopped.connect(_on_simulation_ended)
+	SimRuntime.simulation_pause_toggled.connect(_on_simulation_set_paused)
 
 func _ready() -> void:
-	_rigid_body.freeze = not EditorInterface.is_simulation_running()
-	if EditorInterface.is_simulation_running():
+	_rigid_body.freeze = not SimRuntime.is_simulation_running()
+	if SimRuntime.is_simulation_running():
 		instanced = true
 		_rigid_body.linear_velocity = initial_linear_velocity
 	if color != Color.WHITE:
 		set("color", color)
 
 func _exit_tree() -> void:
-	EditorInterface.simulation_started.disconnect(_on_simulation_started)
-	EditorInterface.simulation_stopped.disconnect(_on_simulation_ended)
-	EditorInterface.simulation_pause_toggled.disconnect(_on_simulation_set_paused)
+	SimRuntime.simulation_started.disconnect(_on_simulation_started)
+	SimRuntime.simulation_stopped.disconnect(_on_simulation_ended)
+	SimRuntime.simulation_pause_toggled.disconnect(_on_simulation_set_paused)
 	if instanced:
 		queue_free()
 
 func selected() -> void:
-	if _paused or not EditorInterface.is_simulation_running():
+	if _paused or not SimRuntime.is_simulation_running():
 		return
 	
 	if _rigid_body.freeze:

--- a/src/PalletSpawner/pallet_spawner.gd
+++ b/src/PalletSpawner/pallet_spawner.gd
@@ -32,19 +32,19 @@ var _first_spawn_done: bool = false
 func _enter_tree() -> void:
 	set_notify_local_transform(true)
 	_reset_spawn_cycle()
-	EditorInterface.simulation_started.connect(_on_simulation_started)
-	EditorInterface.simulation_stopped.connect(_on_simulation_ended)
+	SimRuntime.simulation_started.connect(_on_simulation_started)
+	SimRuntime.simulation_stopped.connect(_on_simulation_ended)
 
 func _ready() -> void:
-	set_physics_process(EditorInterface.is_simulation_running())
+	set_physics_process(SimRuntime.is_simulation_running())
 	_change_texture()
 
 func _exit_tree() -> void:
-	EditorInterface.simulation_started.disconnect(_on_simulation_started)
-	EditorInterface.simulation_stopped.disconnect(_on_simulation_ended)
+	SimRuntime.simulation_started.disconnect(_on_simulation_started)
+	SimRuntime.simulation_stopped.disconnect(_on_simulation_ended)
 
 func _physics_process(delta: float) -> void:
-	if disable or not EditorInterface.is_simulation_running():
+	if disable or not SimRuntime.is_simulation_running():
 		return
 
 	_scan_interval += delta

--- a/src/PushButton/push_button.gd
+++ b/src/PushButton/push_button.gd
@@ -108,7 +108,7 @@ func _validate_property(property: Dictionary) -> void:
 func _enter_tree() -> void:
 	pushbutton_tag_group_name = OIPCommsSetup.default_tag_group(pushbutton_tag_group_name)
 	lamp_tag_group_name = OIPCommsSetup.default_tag_group(lamp_tag_group_name)
-	EditorInterface.simulation_started.connect(_on_simulation_started)
+	SimRuntime.simulation_started.connect(_on_simulation_started)
 	OIPCommsSetup.connect_comms(self, _tag_group_initialized, _tag_group_polled)
 
 
@@ -134,7 +134,7 @@ func _ensure_unique_material() -> void:
 
 
 func _exit_tree() -> void:
-	EditorInterface.simulation_started.disconnect(_on_simulation_started)
+	SimRuntime.simulation_started.disconnect(_on_simulation_started)
 	OIPCommsSetup.disconnect_comms(self, _tag_group_initialized, _tag_group_polled)
 
 

--- a/src/ResizableNode3D/resizable_node_3d.gd
+++ b/src/ResizableNode3D/resizable_node_3d.gd
@@ -70,16 +70,16 @@ func _notification(what: int) -> void:
 					)
 
 func _enter_tree() -> void:
-	if not EditorInterface.transform_requested.is_connected(_transform_requested):
-		EditorInterface.transform_requested.connect(_transform_requested)
-	if not EditorInterface.transform_commited.is_connected(_transform_commited):
-		EditorInterface.transform_commited.connect(_transform_commited)
+	if not SimRuntime.transform_requested.is_connected(_transform_requested):
+		SimRuntime.transform_requested.connect(_transform_requested)
+	if not SimRuntime.transform_commited.is_connected(_transform_commited):
+		SimRuntime.transform_commited.connect(_transform_commited)
 
 func _exit_tree() -> void:
-	if EditorInterface.transform_requested.is_connected(_transform_requested):
-		EditorInterface.transform_requested.disconnect(_transform_requested)
-	if EditorInterface.transform_commited.is_connected(_transform_commited):
-		EditorInterface.transform_commited.disconnect(_transform_commited)
+	if SimRuntime.transform_requested.is_connected(_transform_requested):
+		SimRuntime.transform_requested.disconnect(_transform_requested)
+	if SimRuntime.transform_commited.is_connected(_transform_commited):
+		SimRuntime.transform_commited.disconnect(_transform_commited)
 
 func _transform_requested(data: Dictionary) -> void:
 	if not EditorInterface.get_selection().get_selected_nodes().has(self):

--- a/src/RollerConveyor/curved_roller_conveyor.gd
+++ b/src/RollerConveyor/curved_roller_conveyor.gd
@@ -229,16 +229,16 @@ func _update_flow_arrow() -> void:
 func _enter_tree() -> void:
 	speed_tag_group_name = OIPCommsSetup.default_tag_group(speed_tag_group_name)
 	running_tag_group_name = OIPCommsSetup.default_tag_group(running_tag_group_name)
-	EditorInterface.simulation_started.connect(_on_simulation_started)
-	EditorInterface.simulation_stopped.connect(_on_simulation_ended)
+	SimRuntime.simulation_started.connect(_on_simulation_started)
+	SimRuntime.simulation_stopped.connect(_on_simulation_ended)
 	OIPCommsSetup.connect_comms(self, _tag_group_initialized, _tag_group_polled)
 
 
 func _exit_tree() -> void:
 	if _flow_arrow:
 		FlowDirectionArrow.unregister(_flow_arrow)
-	EditorInterface.simulation_started.disconnect(_on_simulation_started)
-	EditorInterface.simulation_stopped.disconnect(_on_simulation_ended)
+	SimRuntime.simulation_started.disconnect(_on_simulation_started)
+	SimRuntime.simulation_stopped.disconnect(_on_simulation_ended)
 	OIPCommsSetup.disconnect_comms(self, _tag_group_initialized, _tag_group_polled)
 
 
@@ -255,13 +255,13 @@ func _process(delta: float) -> void:
 		var effective_speed := speed * (-1.0 if reverse else 1.0)
 		var uv_speed := effective_speed / (2.0 * PI)
 		var uv_offset := roller_material.uv1_offset
-		if not EditorInterface.is_simulation_paused():
+		if not SimRuntime.is_simulation_paused():
 			uv_offset.x = fmod(fmod(uv_offset.x, 1.0) + uv_speed * delta, 1.0)
 		roller_material.uv1_offset = uv_offset
 
 
 func _physics_process(delta: float) -> void:
-	if EditorInterface.is_simulation_running() and _sb:
+	if SimRuntime.is_simulation_running() and _sb:
 		var local_up := _sb.global_transform.basis.y.normalized()
 		_sb.constant_angular_velocity = -local_up * _angular_speed
 

--- a/src/RollerConveyor/roller_conveyor.gd
+++ b/src/RollerConveyor/roller_conveyor.gd
@@ -121,9 +121,9 @@ func _enter_tree() -> void:
 	speed_tag_group_name = OIPCommsSetup.default_tag_group(speed_tag_group_name)
 	running_tag_group_name = OIPCommsSetup.default_tag_group(running_tag_group_name)
 	if Engine.is_editor_hint():
-		EditorInterface.simulation_started.connect(_on_simulation_started)
-		EditorInterface.simulation_stopped.connect(_on_simulation_ended)
-		running = EditorInterface.is_simulation_running()
+		SimRuntime.simulation_started.connect(_on_simulation_started)
+		SimRuntime.simulation_stopped.connect(_on_simulation_ended)
+		running = SimRuntime.is_simulation_running()
 
 	OIPCommsSetup.connect_comms(self, _tag_group_initialized, _tag_group_polled)
 
@@ -138,10 +138,10 @@ func _exit_tree() -> void:
 	if _flow_arrow:
 		FlowDirectionArrow.unregister(_flow_arrow)
 	if Engine.is_editor_hint():
-		if EditorInterface.simulation_started.is_connected(_on_simulation_started):
-			EditorInterface.simulation_started.disconnect(_on_simulation_started)
-		if EditorInterface.simulation_stopped.is_connected(_on_simulation_ended):
-			EditorInterface.simulation_stopped.disconnect(_on_simulation_ended)
+		if SimRuntime.simulation_started.is_connected(_on_simulation_started):
+			SimRuntime.simulation_started.disconnect(_on_simulation_started)
+		if SimRuntime.simulation_stopped.is_connected(_on_simulation_ended):
+			SimRuntime.simulation_stopped.disconnect(_on_simulation_ended)
 
 	OIPCommsSetup.disconnect_comms(self, _tag_group_initialized, _tag_group_polled)
 

--- a/src/SixAxisRobot/six_axis_robot.gd
+++ b/src/SixAxisRobot/six_axis_robot.gd
@@ -149,18 +149,18 @@ func _enter_tree() -> void:
 	tag_group_name = OIPCommsSetup.default_tag_group(tag_group_name)
 	_setup_node_references()
 
-	if not EditorInterface.simulation_started.is_connected(_on_simulation_started):
-		EditorInterface.simulation_started.connect(_on_simulation_started)
-	if not EditorInterface.simulation_stopped.is_connected(_on_simulation_ended):
-		EditorInterface.simulation_stopped.connect(_on_simulation_ended)
+	if not SimRuntime.simulation_started.is_connected(_on_simulation_started):
+		SimRuntime.simulation_started.connect(_on_simulation_started)
+	if not SimRuntime.simulation_stopped.is_connected(_on_simulation_ended):
+		SimRuntime.simulation_stopped.connect(_on_simulation_ended)
 	OIPCommsSetup.connect_comms(self, _tag_group_initialized, _tag_group_polled)
 
 
 func _exit_tree() -> void:
-	if EditorInterface.simulation_started.is_connected(_on_simulation_started):
-		EditorInterface.simulation_started.disconnect(_on_simulation_started)
-	if EditorInterface.simulation_stopped.is_connected(_on_simulation_ended):
-		EditorInterface.simulation_stopped.disconnect(_on_simulation_ended)
+	if SimRuntime.simulation_started.is_connected(_on_simulation_started):
+		SimRuntime.simulation_started.disconnect(_on_simulation_started)
+	if SimRuntime.simulation_stopped.is_connected(_on_simulation_ended):
+		SimRuntime.simulation_stopped.disconnect(_on_simulation_ended)
 	OIPCommsSetup.disconnect_comms(self, _tag_group_initialized, _tag_group_polled)
 
 
@@ -614,7 +614,8 @@ func move_to_position(target_angles: Array, instant: bool = false) -> void:
 			max_diff = max(max_diff, abs(adjusted_targets[i] - current[i]))
 		
 		var duration: float = max(max_diff / motion_speed, 0.1)
-		EditorInterface.mark_scene_as_unsaved()
+		if Engine.is_editor_hint():
+			EditorInterface.mark_scene_as_unsaved()
 		_motion_tween = create_tween()
 		_motion_tween.set_parallel(true)
 		_motion_tween.tween_property(self, "j1_angle", adjusted_targets[0], duration)

--- a/src/StackLight/stack_light.gd
+++ b/src/StackLight/stack_light.gd
@@ -138,7 +138,7 @@ func _get_property_list() -> Array:
 
 
 func _enter_tree() -> void:
-	EditorInterface.simulation_started.connect(_on_simulation_started)
+	SimRuntime.simulation_started.connect(_on_simulation_started)
 	tag_group_name = OIPCommsSetup.default_tag_group(tag_group_name)
 	OIPCommsSetup.connect_comms(self, Callable(), _tag_group_polled)
 
@@ -177,7 +177,7 @@ func _ready() -> void:
 
 
 func _exit_tree() -> void:
-	EditorInterface.simulation_started.disconnect(_on_simulation_started)
+	SimRuntime.simulation_started.disconnect(_on_simulation_started)
 	OIPCommsSetup.disconnect_comms(self, Callable(), _tag_group_polled)
 	if _segments_container:
 		for i in range(_segments_container.get_child_count()):


### PR DESCRIPTION
## Summary

Enables running OIP scenes outside the editor (`godot --headless`) so projects can validate PLC programs (OPC UA / EthernetIP / Modbus / S7) in CI against an OIP physical model.

Today the parts (BeltConveyor, DiffuseSensor, Pallet, BoxSpawner, ...) connect to `EditorInterface.simulation_started/stopped/pause_toggled` and gate their physics loops on `EditorInterface.is_simulation_running()`. In headless those signals/methods don't exist on the stub `EditorInterface`, so each part throws hundreds of \"Nonexistent function\" errors per second and nothing moves.

This PR introduces a thin **SimRuntime** autoload that mirrors the editor signals the parts already consume, plus an editor-only bridge that re-emits `EditorInterface.simulation_*` into SimRuntime. The 23 parts and `parts/generic_data.gd` are then migrated to talk to SimRuntime instead of EditorInterface. **Editor behavior is unchanged** (Play still drives belts, sensors, pallets); a new headless code path becomes possible for the first time.

A small dock refactor extracts the `register_tag_groups()` helper so non-editor code can register tag groups the same way the dock does today.

## Commits

1. **Add SimRuntime autoload and editor bridge for headless support** — new `addons/sim_runtime/{sim_runtime.gd, sim_runtime_editor_bridge.gd, plugin.cfg}`, two `project.godot` lines.
2. **Migrate parts to SimRuntime for editor/headless parity** — mechanical rename across 21 files (23 .gd files modified). `mark_scene_as_unsaved()` calls in `gantry.gd`/`six_axis_robot.gd` are wrapped with `Engine.is_editor_hint()` since they have no headless equivalent.
3. **Extract OIPCommsRegistration helper from dock** — moves `register_tag_groups()` from `oip_comms_dock.gd` to `addons/oip_comms/comms_registration.gd`.

## Why an autoload (not class_name)

`class_name SimRuntime` would shadow the autoload of the same name. The script uses only `extends Node`; the autoload registration in `project.godot` (`SimRuntime=\"*res://addons/sim_runtime/sim_runtime.gd\"`) provides the global `SimRuntime` identifier.

## Test plan

Validated under **wine 11 (`org.winehq.Wine` flatpak) on Linux x86_64** using the bundled `OIP_v4.7-dev5` Godot fork — there is no Linux native build of OIP yet (separate issue to follow).

- [x] `godot --headless --path . --import` succeeds (124 reimport steps).
- [x] Headless smoke scene with `BeltConveyor` + `DiffuseSensor` runs for 5 s of physics: **0 SCRIPT ERRORs** (down from ~600 / 5 s before).
- [x] Headless OPC UA test connects to a local `asyncua` server at `opc.tcp://localhost:4840`, registers a tag group with `OIPCommsRegistration.register_tag_groups()` (the new helper), and reads `bit` / `float64` values back successfully. `tag_group_initialized` signal fires; `comms_error` does not.
- [ ] Editor Play path: would appreciate a maintainer's smoke test on Windows. The bridge plugin should make this transparent (signals re-emitted), but I don't have a Windows editor to verify.

## Notes for review

- Keeping this as **draft** so review can happen before I open follow-up PRs (issue for Linux builds, additional headless plumbing, and the scenario-loader / assertion-runner that consume this layer).
- The `addons/oip_comms/controls/oip_comms_dock.gd` refactor is intentionally minimal — same behavior, just delegated. Happy to inline back if that's preferred.
- I haven't touched `parts/building.gd` (already gates with `Engine.is_editor_hint()`), the existing autoloads in `addons/oip_ui/Autoload/` (already guarded), or any of the editor-only EditorPlugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)