### PR TITLE
Widen `ChainTransfer.chains` range to 1-10

### DIFF
--- a/src/ChainTransfer/chain_transfer.gd
+++ b/src/ChainTransfer/chain_transfer.gd
@@ -32,10 +32,10 @@ func get_snap_features() -> Array:
 		},
 	]
 
-## Number of chain lanes (2-6).
+## Number of chain lanes (1-10).
 @export var chains: int = 3:
 	set(value):
-		chains = clamp(value, 2, 6)
+		chains = clamp(value, 1, 10)
 		_sync_chain_count()
 
 ## Distance between chain lanes in meters.


### PR DESCRIPTION
## Summary
- Raise the upper bound on `ChainTransfer.chains` from 6 to 10 and lower the floor from 2 to 1, so single-lane and wider configurations can be authored from the inspector.
- Updates the docstring on `chains` to reflect the new `1-10` range.
- 10 chains useful in 60* spur setup
<img width="1714" height="1092" alt="image" src="https://github.com/user-attachments/assets/83d7fc4a-5164-4b05-9902-78429f9c6ed5" />
- 1 chain control gives ability to drop multiple chains to be controlled independently in simulations that require more accuracy