### PR TITLE
Modernize `ColorSensor` and add bool detect/output chain

### DIFF
--- a/src/ColorSensor/color_sensor.gd
+++ b/src/ColorSensor/color_sensor.gd
@@ -3,7 +3,11 @@ class_name ColorSensor
 extends Node3D
 
 ## Maximum detection range of the color sensor in meters.
-@export_custom(PROPERTY_HINT_NONE, "suffix:m") var max_range: float = 1.524
+@export_custom(PROPERTY_HINT_NONE, "suffix:m") var max_range: float = 1.524:
+	set(value):
+		value = clamp(value, 0, 100)
+		max_range = value
+
 ## Toggle visibility of the sensor beam visualization.
 @export var show_beam: bool = true:
 	set(value):
@@ -17,21 +21,17 @@ extends Node3D
 @export var color_detected: Color = Color.BLACK:
 	set(value):
 		color_detected = value
-
-		if color_map.has(value):
-			color_value = color_map[value]
-		else:
-			color_value = 0
-
-		if _tag.is_ready():
-			_tag.write_int32(color_value)
+		_update_color_value()
 
 ## Maps detected colors to integer values for PLC communication.
 @export var color_map: Dictionary[Color, int] = {
 	Color.RED: 1,
 	Color.GREEN: 2,
 	Color.BLUE: 3
-}
+}:
+	set(value):
+		color_map = value
+		_update_color_value()
 
 ## Integer value corresponding to detected color from color_map (read-only).
 @export var color_value: int = 0:
@@ -65,7 +65,9 @@ var _beam_needs_update: bool = true
 
 
 func _validate_property(property: Dictionary) -> void:
-	if property.name == "color_value":
+	if property.name == "color_detected":
+		property.usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY
+	elif property.name == "color_value":
 		property.usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY
 	else:
 		OIPCommsSetup.validate_tag_property(property)
@@ -105,26 +107,22 @@ func _physics_process(_delta: float) -> void:
 	var space_state := get_world_3d().direct_space_state
 	var result := space_state.intersect_ray(_ray_query)
 	var result_distance := max_range
-	var new_color: Color
 	var has_detection := result.size() > 0
 
 	if has_detection:
 		result_distance = start_pos.distance_to(result["position"])
 		var collider: CollisionObject3D = result["collider"]
 		var mesh_instance: MeshInstance3D = collider.get_node("MeshInstance3D")
-		
+
 		var material: StandardMaterial3D = mesh_instance.get_surface_override_material(0)
 		if not material:
 			material = mesh_instance.mesh.surface_get_material(0)
-		
-		new_color = material.albedo_color
+
+		color_detected = material.albedo_color
 	else:
-		new_color = Color.TRANSPARENT
+		color_detected = Color.TRANSPARENT
 
-	if new_color != color_detected:
-		color_detected = new_color
-
-	var beam_color := new_color if new_color != Color.TRANSPARENT else Color.GREEN
+	var beam_color := color_detected if color_detected != Color.TRANSPARENT else Color.GREEN
 	var current_transform := global_transform
 	var beam_end := start_pos + global_transform.basis.z * result_distance
 	if _beam_needs_update or result_distance != _last_result_distance or beam_color != _last_beam_color or current_transform != _last_transform:
@@ -149,6 +147,13 @@ func _update_beam_mesh(start_pos: Vector3, result_distance: float, beam_color: C
 
 func use() -> void:
 	show_beam = not show_beam
+
+
+func _update_color_value() -> void:
+	if color_map.has(color_detected):
+		color_value = color_map[color_detected]
+	else:
+		color_value = 0
 
 
 func _on_simulation_started() -> void:

--- a/src/ColorSensor/color_sensor.gd
+++ b/src/ColorSensor/color_sensor.gd
@@ -17,6 +17,25 @@ extends Node3D
 			if show_beam:
 				_beam_needs_update = true
 
+## When true, output is inverted (false when object detected).
+@export var normally_closed: bool = false:
+	set(value):
+		normally_closed = value
+		_update_output()
+
+## True when an object is within detection range (read-only).
+@export var detected: bool = false:
+	set(value):
+		detected = value
+		_update_output()
+
+## Final output signal after applying normally_closed logic (read-only).
+@export var output: bool = false:
+	set(value):
+		if _output_tag.is_ready() and value != output:
+			_output_tag.write_bit(value)
+		output = value
+
 ## The color currently detected by the sensor (read-only).
 @export var color_detected: Color = Color.BLACK:
 	set(value):
@@ -36,8 +55,8 @@ extends Node3D
 ## Integer value corresponding to detected color from color_map (read-only).
 @export var color_value: int = 0:
 	set(value):
-		if _tag.is_ready() and value != color_value:
-			_tag.write_int32(value)
+		if _color_tag.is_ready() and value != color_value:
+			_color_tag.write_int32(value)
 		color_value = value
 
 var _mesh: ImmediateMesh
@@ -45,7 +64,8 @@ static var _beam_material: StandardMaterial3D = preload("uid://ntmcfd25jgpm")
 var _instance: RID
 var _scenario: RID
 var _ray_query: PhysicsRayQueryParameters3D
-var _tag := OIPCommsTag.new()
+var _color_tag := OIPCommsTag.new()
+var _output_tag := OIPCommsTag.new()
 var _last_result_distance: float = -1.0
 var _last_beam_color: Color = Color.TRANSPARENT
 var _last_transform: Transform3D
@@ -62,6 +82,8 @@ var _beam_needs_update: bool = true
 		tag_groups = value
 ## The tag name for the color value in the selected tag group.[br]Datatype: [code]DINT[/code] (32-bit integer)[br][br]Format varies by protocol:[br][b]EIP:[/b] CIP tag names[br][b]Modbus:[/b] prefix+number (e.g. [code]hr0[/code])[br][b]OPC UA:[/b] full NodeId (e.g. [code]ns=2;s=MyVariable[/code] or [code]ns=2;i=12345[/code]).
 @export var tag_name: String = ""
+## The tag name for the boolean detection output in the selected tag group.[br]Datatype: [code]BOOL[/code][br][br]Format varies by protocol:[br][b]EIP:[/b] CIP tag names[br][b]Modbus:[/b] prefix+number (e.g. [code]co0[/code])[br][b]OPC UA:[/b] full NodeId (e.g. [code]ns=2;s=MyVariable[/code] or [code]ns=2;i=12345[/code]).
+@export var output_tag_name: String = ""
 
 
 func _validate_property(property: Dictionary) -> void:
@@ -69,8 +91,12 @@ func _validate_property(property: Dictionary) -> void:
 		property.usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY
 	elif property.name == "color_value":
 		property.usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY
-	else:
-		OIPCommsSetup.validate_tag_property(property)
+	elif property.name == "detected":
+		property.usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY
+	elif property.name == "output":
+		property.usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY
+	elif not OIPCommsSetup.validate_tag_property(property):
+		OIPCommsSetup.validate_tag_property(property, "tag_group_name", "tag_groups", "output_tag_name")
 
 
 func _enter_tree() -> void:
@@ -108,6 +134,7 @@ func _physics_process(_delta: float) -> void:
 	var result := space_state.intersect_ray(_ray_query)
 	var result_distance := max_range
 	var has_detection := result.size() > 0
+	detected = has_detection
 
 	if has_detection:
 		result_distance = start_pos.distance_to(result["position"])
@@ -156,11 +183,21 @@ func _update_color_value() -> void:
 		color_value = 0
 
 
+func _update_output() -> void:
+	var new_output := detected
+	if normally_closed:
+		new_output = !detected
+	output = new_output
+
+
 func _on_simulation_started() -> void:
 	if enable_comms:
-		_tag.register(tag_group_name, tag_name)
+		_color_tag.register(tag_group_name, tag_name)
+		_output_tag.register(tag_group_name, output_tag_name)
 
 
 func _tag_group_initialized(tag_group_name_param: String) -> void:
-	if _tag.on_group_initialized(tag_group_name_param):
-		_tag.write_int32(color_value)
+	if _color_tag.on_group_initialized(tag_group_name_param):
+		_color_tag.write_int32(color_value)
+	if _output_tag.on_group_initialized(tag_group_name_param):
+		_output_tag.write_bit(output)


### PR DESCRIPTION
## Summary
- Refactor `ColorSensor` to follow the same property-setter pattern as `DiffuseSensor`: `color_detected` flows into `_update_color_value()` → `color_value`, which is the only place the color tag is written. Removes the duplicate tag write that fired twice per detection change.
- Clamp `max_range` to `[0, 100]`, mark `color_detected` as inspector read-only, and recompute `color_value` when `color_map` is edited.
- Add `normally_closed` / `detected` / `output` properties so `ColorSensor` exposes the same boolean detection chain as `DiffuseSensor`. `detected` reflects ray hit; `output` applies the NC inversion.
- Add a second tag (`output_tag_name`, BOOL) for the boolean output alongside the existing `tag_name` (DINT) for the color value. Existing scenes' `tag_name` continues to mean the color tag (no migration required).

## Test plan
- [x] Place a `ColorSensor` over a colored object, verify `color_detected` updates as the object moves in/out of range and `color_value` follows `color_map`.
- [x] Edit `color_map` in the inspector while playing — `color_value` re-evaluates immediately for the current `color_detected`.
- [x] Toggle `normally_closed`; confirm `output` inverts relative to `detected`.
- [x] Wire `tag_name` (DINT) and `output_tag_name` (BOOL) to a PLC/OPC server, verify both tags update independently and only once per change (no duplicate writes).
- [x] Push `max_range` past 100 in the inspector; confirm it clamps.