### PR TITLE
Add bool detect/output chain to `LaserSensor`

### DIFF
--- a/src/LaserSensor/laser_sensor.gd
+++ b/src/LaserSensor/laser_sensor.gd
@@ -127,9 +127,8 @@ func _physics_process(_delta: float) -> void:
 		new_distance = max_range
 		beam_color = Color.GREEN
 
-	if new_distance != distance:
-		distance = new_distance
-	
+	distance = new_distance
+
 	var current_transform := global_transform
 	var beam_end := start_pos + global_transform.basis.z * new_distance
 	if _beam_needs_update or new_distance != _last_distance or beam_color != _last_beam_color or current_transform != _last_transform:

--- a/src/LaserSensor/laser_sensor.gd
+++ b/src/LaserSensor/laser_sensor.gd
@@ -17,11 +17,30 @@ extends Node3D
 			if show_beam:
 				_beam_needs_update = true
 
+## When true, output is inverted (false when object detected).
+@export var normally_closed: bool = false:
+	set(value):
+		normally_closed = value
+		_update_output()
+
+## True when an object is within detection range (read-only).
+@export var detected: bool = false:
+	set(value):
+		detected = value
+		_update_output()
+
+## Final output signal after applying normally_closed logic (read-only).
+@export var output: bool = false:
+	set(value):
+		if _output_tag.is_ready() and value != output:
+			_output_tag.write_bit(value)
+		output = value
+
 ## Current measured distance to detected object (read-only).
 @export_custom(PROPERTY_HINT_NONE, "suffix:m") var distance: float = max_range:
 	set(value):
-		if _tag.is_ready() and value != distance:
-			_tag.write_float32(value)
+		if _distance_tag.is_ready() and value != distance:
+			_distance_tag.write_float32(value)
 		distance = value
 
 var _mesh: ImmediateMesh
@@ -29,7 +48,8 @@ static var _beam_material: StandardMaterial3D = preload("uid://ntmcfd25jgpm")
 var _instance: RID
 var _scenario: RID
 var _ray_query: PhysicsRayQueryParameters3D
-var _tag := OIPCommsTag.new()
+var _distance_tag := OIPCommsTag.new()
+var _output_tag := OIPCommsTag.new()
 var _last_distance: float = -1.0
 var _last_beam_color: Color = Color.TRANSPARENT
 var _last_transform: Transform3D
@@ -46,13 +66,19 @@ var _beam_needs_update: bool = true
 		tag_groups = value
 ## The tag name for the distance value in the selected tag group.[br]Datatype: [code]REAL[/code] (32-bit float)[br][br]Format varies by protocol:[br][b]EIP:[/b] CIP tag names[br][b]Modbus:[/b] prefix+number (e.g. [code]hr0[/code])[br][b]OPC UA:[/b] full NodeId (e.g. [code]ns=2;s=MyVariable[/code] or [code]ns=2;i=12345[/code]).
 @export var tag_name: String = ""
+## The tag name for the boolean detection output in the selected tag group.[br]Datatype: [code]BOOL[/code][br][br]Format varies by protocol:[br][b]EIP:[/b] CIP tag names[br][b]Modbus:[/b] prefix+number (e.g. [code]co0[/code])[br][b]OPC UA:[/b] full NodeId (e.g. [code]ns=2;s=MyVariable[/code] or [code]ns=2;i=12345[/code]).
+@export var output_tag_name: String = ""
 
 
 func _validate_property(property: Dictionary) -> void:
 	if property.name == "distance":
 		property.usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY
-	else:
-		OIPCommsSetup.validate_tag_property(property)
+	elif property.name == "detected":
+		property.usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY
+	elif property.name == "output":
+		property.usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY
+	elif not OIPCommsSetup.validate_tag_property(property):
+		OIPCommsSetup.validate_tag_property(property, "tag_group_name", "tag_groups", "output_tag_name")
 
 
 func _enter_tree() -> void:
@@ -89,9 +115,12 @@ func _physics_process(_delta: float) -> void:
 	var space_state := get_world_3d().direct_space_state
 	var result := space_state.intersect_ray(_ray_query)
 
+	var has_detection := result.size() > 0
+	detected = has_detection
+
 	var new_distance: float
 	var beam_color: Color
-	if result.size() > 0:
+	if has_detection:
 		new_distance = start_pos.distance_to(result["position"])
 		beam_color = Color.RED
 	else:
@@ -127,11 +156,21 @@ func use() -> void:
 	show_beam = not show_beam
 
 
+func _update_output() -> void:
+	var new_output := detected
+	if normally_closed:
+		new_output = !detected
+	output = new_output
+
+
 func _on_simulation_started() -> void:
 	if enable_comms:
-		_tag.register(tag_group_name, tag_name)
+		_distance_tag.register(tag_group_name, tag_name)
+		_output_tag.register(tag_group_name, output_tag_name)
 
 
 func _tag_group_initialized(tag_group_name_param: String) -> void:
-	if _tag.on_group_initialized(tag_group_name_param):
-		_tag.write_float32(distance)
+	if _distance_tag.on_group_initialized(tag_group_name_param):
+		_distance_tag.write_float32(distance)
+	if _output_tag.on_group_initialized(tag_group_name_param):
+		_output_tag.write_bit(output)


### PR DESCRIPTION
## Summary
- Adds `normally_closed` / `detected` / `output` to `LaserSensor` so it exposes the same boolean detection chain as `DiffuseSensor`, alongside the existing distance measurement. `detected` reflects ray hit; `output` applies the NC inversion.
- Adds a second tag (`output_tag_name`, BOOL) for the boolean output, alongside the existing `tag_name` (REAL) for the distance value. Existing scenes' `tag_name` continues to mean the distance tag (no migration required).
- Renames internal `_tag` → `_distance_tag`, adds `_output_tag`. Both tags register on simulation start and write on group initialization.
- Marks `detected` and `output` as inspector read-only (sensed values).

Mirrors the recent `ColorSensor` parity addition (#255).

## Test plan
- [x] Place a `LaserSensor` near an obstacle within `max_range`; confirm `detected` flips true and `distance` updates as the obstacle moves in/out of range.
- [x] Toggle `normally_closed`; confirm `output` inverts relative to `detected`.
- [x] Wire `tag_name` (REAL) and `output_tag_name` (BOOL) to a PLC/OPC server; verify both tags update independently and only on value changes.