### PR TITLE
Publish false to running tag when simulation stops

### DIFF
--- a/addons/oip_comms/controls/oip_comms_dock.gd
+++ b/addons/oip_comms/controls/oip_comms_dock.gd
@@ -35,7 +35,10 @@ func _ready() -> void:
 	last_tag_groups_data = tag_groups_data.duplicate(true)
 
 	EditorInterface.simulation_started.connect(_on_simulation_started)
-	EditorInterface.simulation_stopped.connect(_on_simulation_ended)
+	# Deferred so per-part `_on_simulation_ended` handlers can flush final
+	# tag writes (e.g. `running = false`) before the native singleton tears
+	# down tag handles.
+	EditorInterface.simulation_stopped.connect(_on_simulation_ended, CONNECT_DEFERRED)
 
 	OIPComms.set_enable_comms(enable_comms.button_pressed)
 	OIPComms.comms_error.connect(_on_comms_error)

--- a/src/Conveyor/belt_conveyor.gd
+++ b/src/Conveyor/belt_conveyor.gd
@@ -696,6 +696,8 @@ func _on_simulation_started() -> void:
 
 
 func _on_simulation_ended() -> void:
+	if _running_tag.is_ready():
+		_running_tag.write_bit(false)
 	_belt_position = 0.0
 	if _belt_material:
 		_belt_material.set_shader_parameter("BeltPosition", _belt_position)

--- a/src/Conveyor/belt_spur_conveyor.gd
+++ b/src/Conveyor/belt_spur_conveyor.gd
@@ -846,6 +846,8 @@ func _on_simulation_started() -> void:
 
 
 func _on_simulation_ended() -> void:
+	if _running_tag.is_ready():
+		_running_tag.write_bit(false)
 	_belt_position = 0.0
 	if _belt_material:
 		_belt_material.set_shader_parameter("BeltPosition", _belt_position)

--- a/src/Conveyor/curved_belt_conveyor.gd
+++ b/src/Conveyor/curved_belt_conveyor.gd
@@ -1053,6 +1053,8 @@ func _on_simulation_started() -> void:
 
 
 func _on_simulation_ended() -> void:
+	if _running_tag.is_ready():
+		_running_tag.write_bit(false)
 	_belt_position = 0.0
 	if _belt_material and _belt_material is ShaderMaterial:
 		(_belt_material as ShaderMaterial).set_shader_parameter("BeltPosition", _belt_position)

--- a/src/RollerConveyor/curved_roller_conveyor.gd
+++ b/src/RollerConveyor/curved_roller_conveyor.gd
@@ -1002,6 +1002,8 @@ func _on_simulation_started() -> void:
 
 func _on_simulation_ended() -> void:
 	running = false
+	if _running_tag.is_ready():
+		_running_tag.write_bit(false)
 	if _sb:
 		_sb.constant_angular_velocity = Vector3.ZERO
 	for static_body in _end_static_bodies:

--- a/src/RollerConveyor/roller_conveyor.gd
+++ b/src/RollerConveyor/roller_conveyor.gd
@@ -616,6 +616,8 @@ func _on_simulation_started() -> void:
 
 func _on_simulation_ended() -> void:
 	running = false
+	if _running_tag.is_ready():
+		_running_tag.write_bit(false)
 	_update_conveyor_velocity()
 	if _roller_material:
 		_roller_material.uv1_offset = Vector3.ZERO

--- a/src/RollerConveyor/roller_spur_conveyor.gd
+++ b/src/RollerConveyor/roller_spur_conveyor.gd
@@ -861,6 +861,8 @@ func _on_simulation_started() -> void:
 
 func _on_simulation_ended() -> void:
 	running = false
+	if _running_tag.is_ready():
+		_running_tag.write_bit(false)
 	_update_conveyor_velocity()
 
 


### PR DESCRIPTION
## Summary

- Belt and roller conveyors only wrote the `running` PLC tag from their `speed` / `running` setters. Stopping the simulation left the previously-published value latched in the PLC, so external automation saw the conveyor as still running after the user pressed stop.
- Write `false` to `_running_tag` from `_on_simulation_ended` (guarded by `is_ready()`) in all six conveyor scripts so the PLC sees the conveyor as stopped as soon as the sim ends.

Affected scripts:
- `src/Conveyor/belt_conveyor.gd`
- `src/Conveyor/belt_spur_conveyor.gd`
- `src/Conveyor/curved_belt_conveyor.gd`
- `src/RollerConveyor/roller_conveyor.gd`
- `src/RollerConveyor/roller_spur_conveyor.gd`
- `src/RollerConveyor/curved_roller_conveyor.gd`

## Test plan

- [ ] Configure a belt conveyor with `enable_comms` on and a valid `running_tag_name`.
- [ ] Start the simulation with `speed > 0` and confirm the PLC reads `running = true`.
- [ ] Stop the simulation and confirm the PLC now reads `running = false`.
- [ ] Repeat for a roller conveyor, a spur belt, a spur roller, a curved belt, and a curved roller.